### PR TITLE
Add visibility conforming to overwrites

### DIFF
--- a/src/main/resources/overworld_two.mixins.json
+++ b/src/main/resources/overworld_two.mixins.json
@@ -11,5 +11,8 @@
   ],
   "injectors": {
     "defaultRequire": 1
+  },
+  "overwrites": {
+    "conformVisibility": true
   }
 }


### PR DESCRIPTION
Prevents this mod's overwrites from conflicting when other mods access widen the targets (https://github.com/gegy1000/overworld-two/issues/5)